### PR TITLE
ast: Documentation, Tests and Fixes

### DIFF
--- a/nop.g4
+++ b/nop.g4
@@ -51,7 +51,7 @@ statement
 | STAR statement
 | SELF
 | statement (DOT | RARROW) statement
-| statement LPAREN (statement (COMMA statement)*)? RPAREN
+| statement LPAREN functionParameters RPAREN
 | statement EQUAL EQUAL statement
 | statement EXCLAMATION EQUAL statement
 | statement LESSERTHAN (EQUAL)? statement
@@ -62,6 +62,8 @@ statement
 | arrayInitializer
 | objectInitializer
 ;
+
+functionParameters: (statement (COMMA statement)*)?;
 
 literal
 : STRING

--- a/src/ast/error_listener.go
+++ b/src/ast/error_listener.go
@@ -1,4 +1,4 @@
-package main
+package ast
 
 import "github.com/antlr/antlr4/runtime/Go/antlr"
 

--- a/src/ast/error_listener_test.go
+++ b/src/ast/error_listener_test.go
@@ -1,0 +1,32 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/antlr/antlr4/runtime/Go/antlr"
+)
+
+func TestSyntaxError(t *testing.T) {
+	//Simply invoke syntax error to be sure it actually works.
+	//More of a sanity check to make sure this isn't the root cause of any future problem.
+
+	listener := errorListener{}
+	if listener.EncounteredError {
+		t.Error("Initialized error listener has unexpectedly already listened to an error occurring.")
+	}
+
+	//Faking is hard.
+	recognizer := antlr.BaseLexer{} //BaseRecognizer doesn't actually implement Recognizer. You need Lexer or Parser.
+	recognitionException := antlr.BaseRecognitionException{}
+	listener.SyntaxError(&recognizer, "", 1, 2, "", &recognitionException)
+
+	if !listener.EncounteredError {
+		t.Error("Error listener should have the error encountered flag set!")
+	}
+
+	noDuplicateSanity := errorListener{}
+	if noDuplicateSanity.EncounteredError {
+		//This could really only happen if the ErrorEncountered flag is shared which definitely shouldn't happen.
+		t.Error("Initialized error listener has unexpectedly already listened to an error occurring.")
+	}
+}

--- a/src/ast/golden_file_test.go
+++ b/src/ast/golden_file_test.go
@@ -1,0 +1,29 @@
+package ast_test
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+var _, update = os.LookupEnv("update")
+
+func runTestOnFile(output, goldenFileName string) error {
+	goldenFileLocation := filepath.Join("testdata", goldenFileName)
+	outputBytes := []byte(output)
+	if update {
+		if err := ioutil.WriteFile(goldenFileLocation, outputBytes, 0644); err != nil {
+			return errors.New("failed to update golden file: " + err.Error())
+		}
+	}
+	correct, err := ioutil.ReadFile(goldenFileLocation)
+	if err != nil {
+		return errors.New("failed to read golden file: " + err.Error())
+	}
+	if !bytes.Equal(correct, outputBytes) {
+		return errors.New("bytes do not match!")
+	}
+	return nil
+}

--- a/src/ast/listener.go
+++ b/src/ast/listener.go
@@ -211,11 +211,18 @@ func (n *NopListener) ExitFunctionHeader(ctx *parser.FunctionHeaderContext) {
 	functionParameters := make([]FunctionParameter, 0)
 	for i := 0; i < len(ctx.AllFunctionParameter()); i++ {
 		count := n.stack.Pop().(int)
-		poppedParam := n.stack.PopN(count)
 		for j := 0; j < count; j++ {
-			functionParameters = append(functionParameters, poppedParam[j].(FunctionParameter))
+			poppedParam := n.stack.Pop()
+			functionParameters = append(functionParameters, poppedParam.(FunctionParameter))
 		}
 	}
+
+	//Reverses the array. Stack is first in last out.
+	for i := 0; i < len(functionParameters)/2; i++ {
+		flippedID := len(functionParameters) - i - 1
+		functionParameters[i], functionParameters[flippedID] = functionParameters[flippedID], functionParameters[i]
+	}
+
 	n.stack.Push(FunctionDecl{
 		Name:       ctx.IDENTIFIER().GetText(),
 		Parameters: functionParameters,

--- a/src/ast/listener.go
+++ b/src/ast/listener.go
@@ -431,6 +431,9 @@ func (n *NopListener) ExitStatement(ctx *parser.StatementContext) {
 	case ctx.SELF() != nil:
 		n.stack.Push(Statement{
 			Type: Self,
+			ResolvedType: VariableType{
+				ToInferType: true,
+			},
 		})
 		return
 	case ctx.IDENTIFIER() != nil:
@@ -462,7 +465,10 @@ func (n *NopListener) ExitStatement(ctx *parser.StatementContext) {
 		if len(ctx.AllStatement()) == 1 {
 			pointer := n.stack.Pop().(Statement)
 			n.stack.Push(Statement{
-				Type:      Dereference,
+				Type: Dereference,
+				ResolvedType: VariableType{
+					ToInferType: true,
+				},
 				Arguments: []Statement{pointer},
 			})
 			return
@@ -591,7 +597,10 @@ func (n *NopListener) ExitArrayInitializer(ctx *parser.ArrayInitializerContext) 
 		ResolvedType: n.stack.Pop().(VariableType),
 	}
 	n.stack.Push(Statement{
-		Type:      ArrayInitializer,
+		Type: ArrayInitializer,
+		ResolvedType: VariableType{
+			ToInferType: true,
+		},
 		Arguments: arguments,
 	})
 }
@@ -609,8 +618,10 @@ func (n *NopListener) ExitObjectInitializer(ctx *parser.ObjectInitializerContext
 		ResolvedType: objectType,
 	}
 	n.stack.Push(Statement{
-		Type:      ObjectInitializer,
-		Arguments: arguments,
+		Type: ObjectInitializer,
+		//We already know that object type is being initialized. No point in making the compiler infer it.
+		ResolvedType: objectType,
+		Arguments:    arguments,
 	})
 }
 

--- a/src/ast/listener.go
+++ b/src/ast/listener.go
@@ -630,6 +630,9 @@ func (n *NopListener) ExitStructDecl(ctx *parser.StructDeclContext) {
 //(Antlr still doesn't allow inferring token location)
 func (n *NopListener) ExitStructVar(ctx *parser.StructVarContext) {
 	fieldType := n.stack.Pop().(VariableType)
+	if ctx.PUB() != nil {
+		fieldType.Public = true
+	}
 	identifiers := ctx.AllIDENTIFIER()
 	for _, v := range identifiers {
 		n.stack.Push(Variable{

--- a/src/ast/node.go
+++ b/src/ast/node.go
@@ -1,43 +1,78 @@
 package ast
 
+//OperationType : A constant that defines the type of operation we're dealing with to allow information to be extracted by
+//converting the operation to the correct type.
 type OperationType int8
+
+//StatementType : A constant that defines the type of statement we're dealing with to allow the compiler to generate the correct
+//code for the operation.
 type StatementType int8
 
 const (
+	//VariableDeclaration : An operation that declares a variable. (Let)
 	VariableDeclaration OperationType = iota
+	//Return : An operation that returns a value (ie. returning from a function).
 	Return
+	//If : An operation that carries out a if/else operation.
 	If
+	//Match : An operation that carries out a match operation.
 	Match
+	//Assignment : An operation that changes the value of a property with an evaluated value.
 	Assignment
+	//Eval : An operation that evaluates and throw away the resulting value to use its side effect.
+	//An example is a function call.
 	Eval
 )
 
 const (
+	//Equal : This statement compares if LHS is equal to RHS.
 	Equal StatementType = iota
+	//NotEqual : This statement compares if LHS is not equal to RHS.
 	NotEqual
+	//LesserThan : This statement compares if LHS is lesser than RHS.
 	LesserThan
+	//LesserEqualThan : This statement compares if LHS is lesser than or equal to RHS.
 	LesserEqualThan
+	//GreaterThan : This statement compares if LHS is greater than RHS.
 	GreaterThan
+	//GreaterEqualThan : This statement compares if LHS is greater than or equal to RHS.
 	GreaterEqualThan
+	//FunctionCall : This statement calls a function. Argument is stored in the format: [FunctionToCall, Arguments...]
 	FunctionCall
+	//Multiplication : This statement returns LHS multiplied by RHS.
 	Multiplication
+	//Division : This statement returns LHS divided by RHS.
 	Division
+	//Addition : This statement returns RHS added to LHS.
 	Addition
+	//Subtraction : This statement returns RHS subtracted from LHS.
 	Subtraction
+	//Modulus : This statement returns LHS mod RHS, keeping the sign.
 	Modulus
+	//Self : This is a statement without any arguments. It simply refers to oneself. Used in Impl declarations.
 	Self
+	//Literal : A statement that can be evaluated to a value.
 	Literal
+	//ArrayInitializer : A statement that initializes an array.
 	ArrayInitializer
+	//ObjectInitializer : A statement that initializes an object.
 	ObjectInitializer
+	//ArrayAccessor : A statement that accesses the value of an array. (array[i])
 	ArrayAccessor
+	//PointerAccess : A statement that skips the dereferencing step and reads the struct value. (a->b)
 	PointerAccess
+	//Dereference : A statement that takes in a pointer and return the actual object.
 	Dereference
+	//Property : A statement that access a property of an object (like a field in a struct).
 	Property
+	//PropertyName : These are placeholders to show which fields to access. They'll evaluate to a value if the field exist.
 	PropertyName
+	//Type : A statement that tells ArrayInitializer and ObjectInitializer what type to initialize.
 	Type
 	none //A placeholder used in code to denote that the value is used as-is
 )
 
+//NopFile : The parsed AST. It contains all info about a file.
 type NopFile struct {
 	Source         string
 	CompilerPragma []string
@@ -50,6 +85,7 @@ type NopFile struct {
 	Functions      []FunctionDecl
 }
 
+//StructDecl : A declaration of a struct.
 type StructDecl struct {
 	Public     bool
 	Name       string
@@ -57,28 +93,33 @@ type StructDecl struct {
 	FieldTypes []VariableType
 }
 
+//TraitDecl : A declaration of a trait.
 type TraitDecl struct {
 	Name      string
 	Functions []FunctionDecl
 }
 
+//ImplDecl : A declaration of an implementation (impl).
 type ImplDecl struct {
 	TraitName       string
 	TypeName        VariableType
 	Implementations []FunctionDecl
 }
 
+//VariableDecl : A declaration of variable (let).
 type VariableDecl struct {
 	Targets      []Variable
 	DefaultValue Statement
 	IsConstant   bool
 }
 
+//Variable : A struct that holds information about a variable (that has been declared on is being assigned to).
 type Variable struct {
 	Name string
 	Type VariableType
 }
 
+//VariableType : A struct that holds information about a type.
 type VariableType struct {
 	Name        string
 	ToInferType bool          //Requests the compiler to infer Name and InnerType
@@ -88,6 +129,7 @@ type VariableType struct {
 	Mutable     bool
 }
 
+//FunctionDecl : A declaration of a function (fn).
 type FunctionDecl struct {
 	Name       string
 	Parameters []FunctionParameter
@@ -95,39 +137,47 @@ type FunctionDecl struct {
 	Body       []Operation
 }
 
+//FunctionParameter : A struct that holds the information about a specific function parameter.
 type FunctionParameter struct {
 	Name string
 	Type VariableType
 }
 
+//Operation : An operation that should be ran by a function.
 type Operation struct {
 	Type   OperationType
 	Actual interface{}
 }
 
+//ReturnOperation : An operation that is used in a function to return.
 type ReturnOperation Statement
 
+//IfOperation : An operation that checks if the statement condition is true and run code conditionally.
 type IfOperation struct {
 	Condition Statement
 	IfBlock   []Operation
 	ElseBlock []Operation
 }
 
+//MatchOperation : An operation that chooses the first candidate to match with the list of candidates.
 type MatchOperation struct {
 	Condition Statement
 	Candidate []MatchCandidate
 }
 
+//MatchCandidate : A candidate to be matched by the MatchOperation.
 type MatchCandidate struct {
 	Condition Statement
 	RunBlock  []Operation
 }
 
+//AssignmentOperation : An operation that assigns a value (result of statement) to a field or a variable.
 type AssignmentOperation struct {
 	Target Statement
 	Source Statement
 }
 
+//Statement : A struct containing anything that can be evaluated to a value.
 type Statement struct {
 	Type         StatementType
 	ResolvedType VariableType

--- a/src/ast/parse.go
+++ b/src/ast/parse.go
@@ -1,0 +1,65 @@
+package ast
+
+import (
+	"fmt"
+
+	"github.com/noplang/nopc-go/flags"
+	"github.com/noplang/nopc-go/parser"
+
+	"github.com/antlr/antlr4/runtime/Go/antlr"
+)
+
+//ParseTreeWithLocation : A struct that contains Antlr's parse tree and the location of the original file for debugging.
+type ParseTreeWithLocation struct {
+	Tree     antlr.ParseTree
+	Location string
+}
+
+//ParseFile : A function that takes in the location of a file and outputs the Antlr parse tree with its location.
+func ParseFile(location string) *ParseTreeWithLocation {
+	input, err := antlr.NewFileStream(location)
+	if err != nil {
+		fmt.Println(location + ": Error parsing file through antlr: " + err.Error())
+		return nil
+	}
+
+	lexerError := errorListener{}
+	parserError := errorListener{}
+
+	lexer := parser.NewnopLexer(input)
+	lexer.AddErrorListener(&lexerError)
+
+	stream := antlr.NewCommonTokenStream(lexer, 0)
+
+	parser := parser.NewnopParser(stream)
+	parser.BuildParseTrees = true
+	parser.AddErrorListener(&parserError)
+	tree := parser.Nop_file()
+
+	if lexerError.EncounteredError {
+		fmt.Println(location + ": Failed to tokenize file")
+		return nil
+	}
+	if parserError.EncounteredError {
+		fmt.Println(location + ": Failed to parse file")
+		return nil
+	}
+	return &ParseTreeWithLocation{
+		Tree:     tree,
+		Location: location,
+	}
+}
+
+//GenerateAST : A function that takes in a list of Antlr parse trees and generate a list of AST.
+func GenerateAST(parseTrees []ParseTreeWithLocation) []NopFile {
+	result := make([]NopFile, 0, len(parseTrees))
+	for i, v := range parseTrees {
+		flags.DebugPrint(v.Location + ": walking tree")
+		astWalker := NewNopListener()
+		nopTree := astWalker.Walk(parseTrees[i].Tree)
+		nopTree.Source = parseTrees[i].Location
+		result = append(result, nopTree)
+		flags.DebugPrint(v.Location + ": walked tree")
+	}
+	return result
+}

--- a/src/ast/parse_test.go
+++ b/src/ast/parse_test.go
@@ -1,0 +1,50 @@
+package ast_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/noplang/nopc-go/ast"
+)
+
+func TestHelloWorld(t *testing.T) {
+	testFile("helloworld", false, t)
+}
+
+func TestDiscordDiscussion(t *testing.T) {
+	//Test that AST generation works for the sample (theoratical) code discussed in Discord.
+	testFile("discord_discussion", false, t)
+}
+
+func TestComplexExample(t *testing.T) {
+	testFile("complex", false, t)
+}
+
+func TestFailLexer(t *testing.T) {
+	testFile("lexer_fail", true, t)
+}
+
+func TestFailParser(t *testing.T) {
+	testFile("parser_fail", true, t)
+}
+
+func testFile(testFileName string, shouldFail bool, test *testing.T) {
+	testFileLocation := filepath.Join("testdata", testFileName+".nop")
+
+	tree := ast.ParseFile(testFileLocation)
+	if tree == nil {
+		if !shouldFail {
+			test.Fatal("An error has occurred while parsing a file")
+		}
+		return
+	}
+	if tree != nil && shouldFail {
+		test.Fatal("File that should fail did not fail!")
+	}
+	generatedAST := ast.GenerateAST([]ast.ParseTreeWithLocation{*tree})
+	prettyPrinted := ast.PrettyPrintAST(generatedAST[0])
+
+	if err := runTestOnFile(prettyPrinted, testFileName+".ast.golden"); err != nil {
+		test.Error(err)
+	}
+}

--- a/src/ast/pretty_print.go
+++ b/src/ast/pretty_print.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 )
 
+//PrettyPrintAST : A function that prints a given parsed AST and serializes it into somewhat readable JSON format.
 func PrettyPrintAST(n NopFile) string {
 	s, err := json.MarshalIndent(n, "", "\t")
 	if err != nil {
@@ -15,6 +16,7 @@ func PrettyPrintAST(n NopFile) string {
 	return string(s)
 }
 
+//PrettyPrintASTToFile : A utility function that calls PrettyPrintAST() and saves the resulting string in a file.
 func PrettyPrintASTToFile(n NopFile) {
 	result := PrettyPrintAST(n)
 	file, err := os.Create(n.Source + ".ast")
@@ -32,6 +34,7 @@ func PrettyPrintASTToFile(n NopFile) {
 	w.Flush()
 }
 
+//String : A function that allows operation type to be displayed in its actual enum name instead of the underlying value.
 func (o OperationType) String() string {
 	switch o {
 	case VariableDeclaration:
@@ -50,10 +53,13 @@ func (o OperationType) String() string {
 		return "[OperationType " + strconv.Itoa(int(o)) + "]"
 	}
 }
+
+//MarshalJSON : A function that takes the enum name of an operation type and turns it into the format Go's JSON library need.
 func (o OperationType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(o.String())
 }
 
+//String : A function that allows statement types to be displayed in its actual enum name instead of the underlying value.
 func (s StatementType) String() string {
 	switch s {
 	case Equal:
@@ -106,6 +112,8 @@ func (s StatementType) String() string {
 		return "[StatementType " + strconv.Itoa(int(s)) + "]"
 	}
 }
+
+//MarshalJSON : A function that takes the enum name of a statement type and turns it into the format Go's JSON library need.
 func (s StatementType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String())
 }

--- a/src/ast/pretty_print_test.go
+++ b/src/ast/pretty_print_test.go
@@ -1,0 +1,15 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/noplang/nopc-go/ast"
+)
+
+func TestCleanNopFile(t *testing.T) {
+	output := ast.PrettyPrintAST(ast.NopFile{})
+	err := runTestOnFile(output, "pretty_print_clean.json.golden")
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/src/ast/stack_test.go
+++ b/src/ast/stack_test.go
@@ -1,0 +1,102 @@
+package ast
+
+import "testing"
+
+func TestStackPush(t *testing.T) {
+	testStack := createStack()
+	testStack.Push(1)
+	testStack.Push(2)
+	testStack.Push(3)
+	if !checkArraysMatch(testStack, []interface{}{1, 2, 3}) {
+		t.Error("Stack doesn't match", testStack)
+	}
+}
+
+func TestStackPop(t *testing.T) {
+	testStack := createStack()
+	testStack.Push(1)
+	testStack.Push(2)
+	testStack.Push(3)
+	// Stack = [1,2,3]
+	a := testStack.Pop()
+	if a != 3 {
+		t.Error("Popping failed. Returned incorrect value", a)
+	}
+	// Stack = [1,2]
+	testStack.Push(4)
+	testStack.Push(5)
+	// Stack = [1,2,4,5]
+	b := testStack.Pop()
+	if b != 5 {
+		t.Error("Popping failed. Returned incorrect value", b)
+	}
+	// Stack = [1,2,4]
+	c := testStack.Pop()
+	if c != 4 {
+		t.Error("Popping failed. Returned incorrect value", c)
+	}
+	// Stack = [1,2]
+	if !checkArraysMatch(testStack, []interface{}{1, 2}) {
+		t.Error("Stack doesn't match", testStack)
+	}
+}
+
+func TestStackPopN(t *testing.T) {
+	testStack := createStack()
+	testStack.Push(1)
+	testStack.Push(2)
+	testStack.Push(3)
+	testStack.Push(4)
+	// Stack = [1,2,3,4]
+	a := testStack.PopN(2)
+	if !checkArraysMatch(a, []interface{}{3, 4}) {
+		t.Error("Popping failed. Returned incorrect value", a)
+	}
+	// Stack = [1,2]
+	testStack.Push(5)
+	// Stack = [1,2,5]
+	b := testStack.PopN(3)
+	if !checkArraysMatch(b, []interface{}{1, 2, 5}) {
+		t.Error("Popping failed. Returned incorrect value", b)
+	}
+	// Stack = []
+	if !checkArraysMatch(testStack, []interface{}{}) {
+		t.Error("Stack doesn't match", testStack)
+	}
+}
+
+func TestStackDebugging(t *testing.T) {
+	testStack := createStack()
+	testStack.Push(1)
+	testStack.Push(2)
+	testStack.Push(3)
+	testStack.Pop() //3 should be popped
+	if lastPop != 3 {
+		t.Error("Last pop doesn't match", lastPop)
+	}
+	testStack.PopN(2) //[1, 2] should be popped
+	if !checkArraysMatch(lastPop.(stack), []interface{}{1, 2}) {
+		t.Error("Last pop doesn't match", lastPop)
+	}
+
+	//Check that stack is clean while we're at it
+	if !checkArraysMatch(testStack, []interface{}{}) {
+		t.Error("Stack doesn't match", testStack)
+	}
+}
+
+func createStack() stack {
+	return make([]interface{}, 0)
+}
+
+func checkArraysMatch(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/src/ast/testdata/complex.ast.golden
+++ b/src/ast/testdata/complex.ast.golden
@@ -118,6 +118,17 @@
 					"Name": "whatAreYouTalkingAbout",
 					"Parameters": [
 						{
+							"Name": "d",
+							"Type": {
+								"Name": "i32",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						},
+						{
 							"Name": "e",
 							"Type": {
 								"Name": "i64",
@@ -132,17 +143,6 @@
 							"Name": "f",
 							"Type": {
 								"Name": "i64",
-								"ToInferType": false,
-								"InnerType": null,
-								"Public": false,
-								"Static": false,
-								"Mutable": false
-							}
-						},
-						{
-							"Name": "d",
-							"Type": {
-								"Name": "i32",
 								"ToInferType": false,
 								"InnerType": null,
 								"Public": false,
@@ -193,6 +193,17 @@
 					"Name": "whatAreYouTalkingAbout",
 					"Parameters": [
 						{
+							"Name": "d",
+							"Type": {
+								"Name": "i32",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						},
+						{
 							"Name": "e",
 							"Type": {
 								"Name": "i64",
@@ -207,17 +218,6 @@
 							"Name": "f",
 							"Type": {
 								"Name": "i64",
-								"ToInferType": false,
-								"InnerType": null,
-								"Public": false,
-								"Static": false,
-								"Mutable": false
-							}
-						},
-						{
-							"Name": "d",
-							"Type": {
-								"Name": "i32",
 								"ToInferType": false,
 								"InnerType": null,
 								"Public": false,
@@ -3140,6 +3140,66 @@
 			"Name": "allTypeModifiers",
 			"Parameters": [
 				{
+					"Name": "a",
+					"Type": {
+						"Name": "Pointer",
+						"ToInferType": false,
+						"InnerType": {
+							"Name": "Pointer",
+							"ToInferType": false,
+							"InnerType": {
+								"Name": "Pointer",
+								"ToInferType": false,
+								"InnerType": {
+									"Name": "Pointer",
+									"ToInferType": false,
+									"InnerType": {
+										"Name": "Array",
+										"ToInferType": false,
+										"InnerType": {
+											"Name": "Pointer",
+											"ToInferType": false,
+											"InnerType": {
+												"Name": "Array",
+												"ToInferType": false,
+												"InnerType": {
+													"Name": "bool",
+													"ToInferType": false,
+													"InnerType": null,
+													"Public": false,
+													"Static": false,
+													"Mutable": false
+												},
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				},
+				{
 					"Name": "b",
 					"Type": {
 						"Name": "Array",
@@ -3204,66 +3264,6 @@
 						"Public": false,
 						"Static": false,
 						"Mutable": true
-					}
-				},
-				{
-					"Name": "a",
-					"Type": {
-						"Name": "Pointer",
-						"ToInferType": false,
-						"InnerType": {
-							"Name": "Pointer",
-							"ToInferType": false,
-							"InnerType": {
-								"Name": "Pointer",
-								"ToInferType": false,
-								"InnerType": {
-									"Name": "Pointer",
-									"ToInferType": false,
-									"InnerType": {
-										"Name": "Array",
-										"ToInferType": false,
-										"InnerType": {
-											"Name": "Pointer",
-											"ToInferType": false,
-											"InnerType": {
-												"Name": "Array",
-												"ToInferType": false,
-												"InnerType": {
-													"Name": "bool",
-													"ToInferType": false,
-													"InnerType": null,
-													"Public": false,
-													"Static": false,
-													"Mutable": false
-												},
-												"Public": false,
-												"Static": false,
-												"Mutable": false
-											},
-											"Public": false,
-											"Static": false,
-											"Mutable": false
-										},
-										"Public": false,
-										"Static": false,
-										"Mutable": false
-									},
-									"Public": false,
-									"Static": false,
-									"Mutable": false
-								},
-								"Public": false,
-								"Static": false,
-								"Mutable": false
-							},
-							"Public": false,
-							"Static": false,
-							"Mutable": false
-						},
-						"Public": false,
-						"Static": false,
-						"Mutable": false
 					}
 				}
 			],

--- a/src/ast/testdata/complex.ast.golden
+++ b/src/ast/testdata/complex.ast.golden
@@ -336,7 +336,7 @@
 				}
 			],
 			"DefaultValue": {
-				"Type": "[Property]",
+				"Type": "[FunctionCall]",
 				"ResolvedType": {
 					"Name": "",
 					"ToInferType": true,
@@ -348,7 +348,7 @@
 				"LiteralValue": null,
 				"Arguments": [
 					{
-						"Type": "[PropertyName]",
+						"Type": "[Property]",
 						"ResolvedType": {
 							"Name": "",
 							"ToInferType": true,
@@ -357,21 +357,35 @@
 							"Static": false,
 							"Mutable": false
 						},
-						"LiteralValue": "packageA",
-						"Arguments": null
-					},
-					{
-						"Type": "[PropertyName]",
-						"ResolvedType": {
-							"Name": "",
-							"ToInferType": true,
-							"InnerType": null,
-							"Public": false,
-							"Static": false,
-							"Mutable": false
-						},
-						"LiteralValue": "someMysteriousFunction",
-						"Arguments": null
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "packageA",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "someMysteriousFunction",
+								"Arguments": null
+							}
+						]
 					}
 				]
 			},
@@ -416,7 +430,7 @@
 				}
 			],
 			"DefaultValue": {
-				"Type": "[Property]",
+				"Type": "[FunctionCall]",
 				"ResolvedType": {
 					"Name": "",
 					"ToInferType": true,
@@ -428,7 +442,7 @@
 				"LiteralValue": null,
 				"Arguments": [
 					{
-						"Type": "[PropertyName]",
+						"Type": "[Property]",
 						"ResolvedType": {
 							"Name": "",
 							"ToInferType": true,
@@ -437,21 +451,35 @@
 							"Static": false,
 							"Mutable": false
 						},
-						"LiteralValue": "packageB",
-						"Arguments": null
-					},
-					{
-						"Type": "[PropertyName]",
-						"ResolvedType": {
-							"Name": "",
-							"ToInferType": true,
-							"InnerType": null,
-							"Public": false,
-							"Static": false,
-							"Mutable": false
-						},
-						"LiteralValue": "iDareYouChangeUs",
-						"Arguments": null
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "packageB",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "iDareYouChangeUs",
+								"Arguments": null
+							}
+						]
 					}
 				]
 			},
@@ -574,7 +602,7 @@
 							}
 						],
 						"DefaultValue": {
-							"Type": "[Property]",
+							"Type": "[FunctionCall]",
 							"ResolvedType": {
 								"Name": "",
 								"ToInferType": true,
@@ -586,7 +614,7 @@
 							"LiteralValue": null,
 							"Arguments": [
 								{
-									"Type": "[PropertyName]",
+									"Type": "[Property]",
 									"ResolvedType": {
 										"Name": "",
 										"ToInferType": true,
@@ -595,21 +623,35 @@
 										"Static": false,
 										"Mutable": false
 									},
-									"LiteralValue": "packageA",
-									"Arguments": null
-								},
-								{
-									"Type": "[PropertyName]",
-									"ResolvedType": {
-										"Name": "",
-										"ToInferType": true,
-										"InnerType": null,
-										"Public": false,
-										"Static": false,
-										"Mutable": false
-									},
-									"LiteralValue": "someMysteriousFunction",
-									"Arguments": null
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "packageA",
+											"Arguments": null
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "someMysteriousFunction",
+											"Arguments": null
+										}
+									]
 								}
 							]
 						},
@@ -666,7 +708,7 @@
 									"Type": "[FunctionCall]",
 									"ResolvedType": {
 										"Name": "",
-										"ToInferType": false,
+										"ToInferType": true,
 										"InnerType": null,
 										"Public": false,
 										"Static": false,
@@ -784,7 +826,7 @@
 									"Type": "[FunctionCall]",
 									"ResolvedType": {
 										"Name": "",
-										"ToInferType": false,
+										"ToInferType": true,
 										"InnerType": null,
 										"Public": false,
 										"Static": false,
@@ -856,7 +898,7 @@
 									"Type": "[FunctionCall]",
 									"ResolvedType": {
 										"Name": "",
-										"ToInferType": false,
+										"ToInferType": true,
 										"InnerType": null,
 										"Public": false,
 										"Static": false,
@@ -961,7 +1003,7 @@
 											"Type": "[FunctionCall]",
 											"ResolvedType": {
 												"Name": "",
-												"ToInferType": false,
+												"ToInferType": true,
 												"InnerType": null,
 												"Public": false,
 												"Static": false,
@@ -1048,7 +1090,7 @@
 											"Type": "[FunctionCall]",
 											"ResolvedType": {
 												"Name": "",
-												"ToInferType": false,
+												"ToInferType": true,
 												"InnerType": null,
 												"Public": false,
 												"Static": false,
@@ -1135,7 +1177,7 @@
 											"Type": "[FunctionCall]",
 											"ResolvedType": {
 												"Name": "",
-												"ToInferType": false,
+												"ToInferType": true,
 												"InnerType": null,
 												"Public": false,
 												"Static": false,
@@ -1205,7 +1247,7 @@
 											"Type": "[FunctionCall]",
 											"ResolvedType": {
 												"Name": "",
-												"ToInferType": false,
+												"ToInferType": true,
 												"InnerType": null,
 												"Public": false,
 												"Static": false,
@@ -1337,7 +1379,7 @@
 						"Type": "[FunctionCall]",
 						"ResolvedType": {
 							"Name": "",
-							"ToInferType": false,
+							"ToInferType": true,
 							"InnerType": null,
 							"Public": false,
 							"Static": false,
@@ -1393,7 +1435,7 @@
 						"Type": "[FunctionCall]",
 						"ResolvedType": {
 							"Name": "",
-							"ToInferType": false,
+							"ToInferType": true,
 							"InnerType": null,
 							"Public": false,
 							"Static": false,
@@ -1446,7 +1488,7 @@
 				{
 					"Type": "[EvaluatedStatement]",
 					"Actual": {
-						"Type": "[PropertyName]",
+						"Type": "[FunctionCall]",
 						"ResolvedType": {
 							"Name": "",
 							"ToInferType": true,
@@ -1455,8 +1497,22 @@
 							"Static": false,
 							"Mutable": false
 						},
-						"LiteralValue": "allMiscIdentifiers",
-						"Arguments": null
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "allMiscIdentifiers",
+								"Arguments": null
+							}
+						]
 					}
 				}
 			]
@@ -1856,7 +1912,7 @@
 						"Type": "[FunctionCall]",
 						"ResolvedType": {
 							"Name": "",
-							"ToInferType": false,
+							"ToInferType": true,
 							"InnerType": null,
 							"Public": false,
 							"Static": false,
@@ -2616,7 +2672,7 @@
 						"Type": "[FunctionCall]",
 						"ResolvedType": {
 							"Name": "",
-							"ToInferType": false,
+							"ToInferType": true,
 							"InnerType": null,
 							"Public": false,
 							"Static": false,

--- a/src/ast/testdata/complex.ast.golden
+++ b/src/ast/testdata/complex.ast.golden
@@ -25,7 +25,7 @@
 					"Name": "i32",
 					"ToInferType": false,
 					"InnerType": null,
-					"Public": false,
+					"Public": true,
 					"Static": false,
 					"Mutable": false
 				},
@@ -41,7 +41,7 @@
 					"Name": "i64",
 					"ToInferType": false,
 					"InnerType": null,
-					"Public": false,
+					"Public": true,
 					"Static": false,
 					"Mutable": false
 				}

--- a/src/ast/testdata/complex.ast.golden
+++ b/src/ast/testdata/complex.ast.golden
@@ -2850,7 +2850,7 @@
 									"Type": "[Dereference]",
 									"ResolvedType": {
 										"Name": "",
-										"ToInferType": false,
+										"ToInferType": true,
 										"InnerType": null,
 										"Public": false,
 										"Static": false,
@@ -2862,7 +2862,7 @@
 											"Type": "[Self]",
 											"ResolvedType": {
 												"Name": "",
-												"ToInferType": false,
+												"ToInferType": true,
 												"InnerType": null,
 												"Public": false,
 												"Static": false,
@@ -2911,7 +2911,7 @@
 							"Type": "[ArrayInitializer]",
 							"ResolvedType": {
 								"Name": "",
-								"ToInferType": false,
+								"ToInferType": true,
 								"InnerType": null,
 								"Public": false,
 								"Static": false,
@@ -2969,7 +2969,7 @@
 							"Type": "[ArrayInitializer]",
 							"ResolvedType": {
 								"Name": "",
-								"ToInferType": false,
+								"ToInferType": true,
 								"InnerType": null,
 								"Public": false,
 								"Static": false,
@@ -3078,7 +3078,7 @@
 						"DefaultValue": {
 							"Type": "[ObjectInitializer]",
 							"ResolvedType": {
-								"Name": "",
+								"Name": "a",
 								"ToInferType": false,
 								"InnerType": null,
 								"Public": false,

--- a/src/ast/testdata/complex.ast.golden
+++ b/src/ast/testdata/complex.ast.golden
@@ -1,0 +1,3281 @@
+{
+	"Source": "testdata/complex.nop",
+	"CompilerPragma": [
+		"#compilerPragmaA",
+		"#compilerPragmaB",
+		"#compilerPragmaC",
+		"#FailAfterASTGeneration"
+	],
+	"Import": [
+		"packageA",
+		"packageB",
+		"packageC"
+	],
+	"Structs": [
+		{
+			"Public": false,
+			"Name": "a",
+			"FieldNames": [
+				"p",
+				"q",
+				"r"
+			],
+			"FieldTypes": [
+				{
+					"Name": "i32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				{
+					"Name": "i32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				{
+					"Name": "i64",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				}
+			]
+		},
+		{
+			"Public": true,
+			"Name": "b",
+			"FieldNames": [
+				"a",
+				"b",
+				"c",
+				"d",
+				"e",
+				"f"
+			],
+			"FieldTypes": [
+				{
+					"Name": "i32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				{
+					"Name": "i32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				{
+					"Name": "i32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				{
+					"Name": "f32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				{
+					"Name": "f32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				{
+					"Name": "f32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				}
+			]
+		}
+	],
+	"Traits": [
+		{
+			"Name": "c",
+			"Functions": [
+				{
+					"Name": "whatAreYouTalkingAbout",
+					"Parameters": [
+						{
+							"Name": "e",
+							"Type": {
+								"Name": "i64",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						},
+						{
+							"Name": "f",
+							"Type": {
+								"Name": "i64",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						},
+						{
+							"Name": "d",
+							"Type": {
+								"Name": "i32",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						}
+					],
+					"ReturnType": {
+						"Name": "ustring",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					},
+					"Body": null
+				},
+				{
+					"Name": "noOpThx",
+					"Parameters": [],
+					"ReturnType": {
+						"Name": "",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					},
+					"Body": null
+				}
+			]
+		}
+	],
+	"Impls": [
+		{
+			"TraitName": "c",
+			"TypeName": {
+				"Name": "a",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Implementations": [
+				{
+					"Name": "whatAreYouTalkingAbout",
+					"Parameters": [
+						{
+							"Name": "e",
+							"Type": {
+								"Name": "i64",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						},
+						{
+							"Name": "f",
+							"Type": {
+								"Name": "i64",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						},
+						{
+							"Name": "d",
+							"Type": {
+								"Name": "i32",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						}
+					],
+					"ReturnType": {
+						"Name": "ustring",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					},
+					"Body": [
+						{
+							"Type": "[ReturnStatement]",
+							"Actual": {
+								"Type": "[Literal]",
+								"ResolvedType": {
+									"Name": "ustring",
+									"ToInferType": false,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "I am cute",
+								"Arguments": null
+							}
+						}
+					]
+				},
+				{
+					"Name": "noOpThx",
+					"Parameters": [],
+					"ReturnType": {
+						"Name": "",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					},
+					"Body": []
+				}
+			]
+		}
+	],
+	"Globals": [
+		{
+			"Targets": [
+				{
+					"Name": "d",
+					"Type": {
+						"Name": "",
+						"ToInferType": true,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				}
+			],
+			"DefaultValue": {
+				"Type": "[Literal]",
+				"ResolvedType": {
+					"Name": "i64",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				"LiteralValue": 3,
+				"Arguments": null
+			},
+			"IsConstant": false
+		},
+		{
+			"Targets": [
+				{
+					"Name": "e",
+					"Type": {
+						"Name": "i64",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				},
+				{
+					"Name": "f",
+					"Type": {
+						"Name": "i64",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				},
+				{
+					"Name": "g",
+					"Type": {
+						"Name": "f64",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				}
+			],
+			"DefaultValue": {
+				"Type": "[Property]",
+				"ResolvedType": {
+					"Name": "",
+					"ToInferType": true,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				"LiteralValue": null,
+				"Arguments": [
+					{
+						"Type": "[PropertyName]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": true,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": "packageA",
+						"Arguments": null
+					},
+					{
+						"Type": "[PropertyName]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": true,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": "someMysteriousFunction",
+						"Arguments": null
+					}
+				]
+			},
+			"IsConstant": false
+		}
+	],
+	"Constants": [
+		{
+			"Targets": [
+				{
+					"Name": "h",
+					"Type": {
+						"Name": "",
+						"ToInferType": true,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				},
+				{
+					"Name": "i",
+					"Type": {
+						"Name": "",
+						"ToInferType": true,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				},
+				{
+					"Name": "j",
+					"Type": {
+						"Name": "",
+						"ToInferType": true,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				}
+			],
+			"DefaultValue": {
+				"Type": "[Property]",
+				"ResolvedType": {
+					"Name": "",
+					"ToInferType": true,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				"LiteralValue": null,
+				"Arguments": [
+					{
+						"Type": "[PropertyName]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": true,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": "packageB",
+						"Arguments": null
+					},
+					{
+						"Type": "[PropertyName]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": true,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": "iDareYouChangeUs",
+						"Arguments": null
+					}
+				]
+			},
+			"IsConstant": true
+		}
+	],
+	"Functions": [
+		{
+			"Name": "main",
+			"Parameters": [],
+			"ReturnType": {
+				"Name": "",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Body": [
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "x",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[Literal]",
+							"ResolvedType": {
+								"Name": "i64",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": 3,
+							"Arguments": null
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "y",
+								"Type": {
+									"Name": "i64",
+									"ToInferType": false,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[Literal]",
+							"ResolvedType": {
+								"Name": "i64",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": 5,
+							"Arguments": null
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "a",
+								"Type": {
+									"Name": "i64",
+									"ToInferType": false,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							},
+							{
+								"Name": "b",
+								"Type": {
+									"Name": "i64",
+									"ToInferType": false,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							},
+							{
+								"Name": "c",
+								"Type": {
+									"Name": "f64",
+									"ToInferType": false,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[Property]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "packageA",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "someMysteriousFunction",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[IfStatement]",
+					"Actual": {
+						"Condition": {
+							"Type": "\u003e",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "i64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 0,
+									"Arguments": null
+								}
+							]
+						},
+						"IfBlock": [
+							{
+								"Type": "[EvaluatedStatement]",
+								"Actual": {
+									"Type": "[FunctionCall]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[Property]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": [
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "packageB",
+													"Arguments": null
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "largerThanZero",
+													"Arguments": null
+												}
+											]
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "a",
+											"Arguments": null
+										}
+									]
+								}
+							}
+						],
+						"ElseBlock": []
+					}
+				},
+				{
+					"Type": "[IfStatement]",
+					"Actual": {
+						"Condition": {
+							"Type": "\u003e",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "i64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 0,
+									"Arguments": null
+								}
+							]
+						},
+						"IfBlock": [
+							{
+								"Type": "[EvaluatedStatement]",
+								"Actual": {
+									"Type": "[FunctionCall]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[Property]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": [
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "packageB",
+													"Arguments": null
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "largerThanZero",
+													"Arguments": null
+												}
+											]
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "b",
+											"Arguments": null
+										}
+									]
+								}
+							}
+						],
+						"ElseBlock": [
+							{
+								"Type": "[EvaluatedStatement]",
+								"Actual": {
+									"Type": "[FunctionCall]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[Property]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": [
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "packageB",
+													"Arguments": null
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "smallerThanZero",
+													"Arguments": null
+												}
+											]
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "b",
+											"Arguments": null
+										}
+									]
+								}
+							}
+						]
+					}
+				},
+				{
+					"Type": "[MatchStatement]",
+					"Actual": {
+						"Condition": {
+							"Type": "[PropertyName]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": "c",
+							"Arguments": null
+						},
+						"Candidate": [
+							{
+								"Condition": {
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "f64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 3,
+									"Arguments": null
+								},
+								"RunBlock": [
+									{
+										"Type": "[EvaluatedStatement]",
+										"Actual": {
+											"Type": "[FunctionCall]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": false,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": [
+												{
+													"Type": "[Property]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": null,
+													"Arguments": [
+														{
+															"Type": "[PropertyName]",
+															"ResolvedType": {
+																"Name": "",
+																"ToInferType": true,
+																"InnerType": null,
+																"Public": false,
+																"Static": false,
+																"Mutable": false
+															},
+															"LiteralValue": "packageB",
+															"Arguments": null
+														},
+														{
+															"Type": "[PropertyName]",
+															"ResolvedType": {
+																"Name": "",
+																"ToInferType": true,
+																"InnerType": null,
+																"Public": false,
+																"Static": false,
+																"Mutable": false
+															},
+															"LiteralValue": "largerThanZero",
+															"Arguments": null
+														}
+													]
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "c",
+													"Arguments": null
+												}
+											]
+										}
+									}
+								]
+							},
+							{
+								"Condition": {
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "f64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 2,
+									"Arguments": null
+								},
+								"RunBlock": [
+									{
+										"Type": "[EvaluatedStatement]",
+										"Actual": {
+											"Type": "[FunctionCall]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": false,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": [
+												{
+													"Type": "[Property]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": null,
+													"Arguments": [
+														{
+															"Type": "[PropertyName]",
+															"ResolvedType": {
+																"Name": "",
+																"ToInferType": true,
+																"InnerType": null,
+																"Public": false,
+																"Static": false,
+																"Mutable": false
+															},
+															"LiteralValue": "packageA",
+															"Arguments": null
+														},
+														{
+															"Type": "[PropertyName]",
+															"ResolvedType": {
+																"Name": "",
+																"ToInferType": true,
+																"InnerType": null,
+																"Public": false,
+																"Static": false,
+																"Mutable": false
+															},
+															"LiteralValue": "yay",
+															"Arguments": null
+														}
+													]
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "c",
+													"Arguments": null
+												}
+											]
+										}
+									}
+								]
+							},
+							{
+								"Condition": {
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "f64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 1,
+									"Arguments": null
+								},
+								"RunBlock": [
+									{
+										"Type": "[EvaluatedStatement]",
+										"Actual": {
+											"Type": "[FunctionCall]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": false,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": [
+												{
+													"Type": "[Property]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": null,
+													"Arguments": [
+														{
+															"Type": "[PropertyName]",
+															"ResolvedType": {
+																"Name": "",
+																"ToInferType": true,
+																"InnerType": null,
+																"Public": false,
+																"Static": false,
+																"Mutable": false
+															},
+															"LiteralValue": "packageB",
+															"Arguments": null
+														},
+														{
+															"Type": "[PropertyName]",
+															"ResolvedType": {
+																"Name": "",
+																"ToInferType": true,
+																"InnerType": null,
+																"Public": false,
+																"Static": false,
+																"Mutable": false
+															},
+															"LiteralValue": "iRanOutOfFunctionNames",
+															"Arguments": null
+														}
+													]
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "c",
+													"Arguments": null
+												}
+											]
+										}
+									},
+									{
+										"Type": "[EvaluatedStatement]",
+										"Actual": {
+											"Type": "[FunctionCall]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": false,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": [
+												{
+													"Type": "[Property]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": null,
+													"Arguments": [
+														{
+															"Type": "[PropertyName]",
+															"ResolvedType": {
+																"Name": "",
+																"ToInferType": true,
+																"InnerType": null,
+																"Public": false,
+																"Static": false,
+																"Mutable": false
+															},
+															"LiteralValue": "packageB",
+															"Arguments": null
+														},
+														{
+															"Type": "[PropertyName]",
+															"ResolvedType": {
+																"Name": "",
+																"ToInferType": true,
+																"InnerType": null,
+																"Public": false,
+																"Static": false,
+																"Mutable": false
+															},
+															"LiteralValue": "iAmStillRunningOutOfFunctionName",
+															"Arguments": null
+														}
+													]
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "a",
+													"Arguments": null
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "b",
+													"Arguments": null
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "c",
+													"Arguments": null
+												}
+											]
+										}
+									}
+								]
+							}
+						]
+					}
+				},
+				{
+					"Type": "[Assignment]",
+					"Actual": {
+						"Target": {
+							"Type": "[PropertyName]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": "y",
+							"Arguments": null
+						},
+						"Source": {
+							"Type": "[Literal]",
+							"ResolvedType": {
+								"Name": "i64",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": 9,
+							"Arguments": null
+						}
+					}
+				},
+				{
+					"Type": "[EvaluatedStatement]",
+					"Actual": {
+						"Type": "[FunctionCall]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": false,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "allBooleanOperators",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "x",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "y",
+								"Arguments": null
+							}
+						]
+					}
+				},
+				{
+					"Type": "[EvaluatedStatement]",
+					"Actual": {
+						"Type": "[FunctionCall]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": false,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "allMathOperators",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "x",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "y",
+								"Arguments": null
+							}
+						]
+					}
+				},
+				{
+					"Type": "[EvaluatedStatement]",
+					"Actual": {
+						"Type": "[PropertyName]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": true,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": "allMiscIdentifiers",
+						"Arguments": null
+					}
+				}
+			]
+		},
+		{
+			"Name": "allBooleanOperators",
+			"Parameters": [
+				{
+					"Name": "a",
+					"Type": {
+						"Name": "i64",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				},
+				{
+					"Name": "b",
+					"Type": {
+						"Name": "i64",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				}
+			],
+			"ReturnType": {
+				"Name": "bool",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Body": [
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "k",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "==",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "l",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "!=",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "m",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "\u003c",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "n",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "\u003e",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "o",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "\u003c=",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "p",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "\u003e=",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[EvaluatedStatement]",
+					"Actual": {
+						"Type": "[FunctionCall]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": false,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[Property]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": null,
+								"Arguments": [
+									{
+										"Type": "[PropertyName]",
+										"ResolvedType": {
+											"Name": "",
+											"ToInferType": true,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": "packageB",
+										"Arguments": null
+									},
+									{
+										"Type": "[PropertyName]",
+										"ResolvedType": {
+											"Name": "",
+											"ToInferType": true,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": "dealWithThese",
+										"Arguments": null
+									}
+								]
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "l",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "m",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "n",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "o",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "p",
+								"Arguments": null
+							}
+						]
+					}
+				},
+				{
+					"Type": "[ReturnStatement]",
+					"Actual": {
+						"Type": "[PropertyName]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": true,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": "k",
+						"Arguments": null
+					}
+				}
+			]
+		},
+		{
+			"Name": "allMathOperators",
+			"Parameters": [
+				{
+					"Name": "a",
+					"Type": {
+						"Name": "i64",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				},
+				{
+					"Name": "b",
+					"Type": {
+						"Name": "i64",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				}
+			],
+			"ReturnType": {
+				"Name": "i64",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Body": [
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "q",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[Addition]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "r",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[Subtraction]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "s",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[Multiplication]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "t",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[Division]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "u",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[Modulus]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[Assignment]",
+					"Actual": {
+						"Target": {
+							"Type": "[PropertyName]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": "q",
+							"Arguments": null
+						},
+						"Source": {
+							"Type": "[Addition]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "q",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								}
+							]
+						}
+					}
+				},
+				{
+					"Type": "[Assignment]",
+					"Actual": {
+						"Target": {
+							"Type": "[PropertyName]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": "r",
+							"Arguments": null
+						},
+						"Source": {
+							"Type": "[Subtraction]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "r",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						}
+					}
+				},
+				{
+					"Type": "[Assignment]",
+					"Actual": {
+						"Target": {
+							"Type": "[PropertyName]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": "s",
+							"Arguments": null
+						},
+						"Source": {
+							"Type": "[Multiplication]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "s",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "a",
+									"Arguments": null
+								}
+							]
+						}
+					}
+				},
+				{
+					"Type": "[Assignment]",
+					"Actual": {
+						"Target": {
+							"Type": "[PropertyName]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": "t",
+							"Arguments": null
+						},
+						"Source": {
+							"Type": "[Division]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "t",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						}
+					}
+				},
+				{
+					"Type": "[Assignment]",
+					"Actual": {
+						"Target": {
+							"Type": "[PropertyName]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": "u",
+							"Arguments": null
+						},
+						"Source": {
+							"Type": "[Modulus]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "u",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								}
+							]
+						}
+					}
+				},
+				{
+					"Type": "[EvaluatedStatement]",
+					"Actual": {
+						"Type": "[FunctionCall]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": false,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[Property]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": null,
+								"Arguments": [
+									{
+										"Type": "[PropertyName]",
+										"ResolvedType": {
+											"Name": "",
+											"ToInferType": true,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": "packageB",
+										"Arguments": null
+									},
+									{
+										"Type": "[PropertyName]",
+										"ResolvedType": {
+											"Name": "",
+											"ToInferType": true,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": "dealWithThese",
+										"Arguments": null
+									}
+								]
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "q",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "r",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "s",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "t",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "u",
+								"Arguments": null
+							}
+						]
+					}
+				},
+				{
+					"Type": "[ReturnStatement]",
+					"Actual": {
+						"Type": "[PropertyName]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": true,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": "q",
+						"Arguments": null
+					}
+				}
+			]
+		},
+		{
+			"Name": "allMiscIdentifiers",
+			"Parameters": [],
+			"ReturnType": {
+				"Name": "",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Body": [
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "v",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[PointerAccess]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[Dereference]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[Self]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": false,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": null
+										}
+									]
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "x",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[Assignment]",
+					"Actual": {
+						"Target": {
+							"Type": "[PropertyName]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": "v",
+							"Arguments": null
+						},
+						"Source": {
+							"Type": "[ArrayInitializer]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[Type]",
+									"ResolvedType": {
+										"Name": "bool",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "i64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 0,
+									"Arguments": null
+								}
+							]
+						}
+					}
+				},
+				{
+					"Type": "[Assignment]",
+					"Actual": {
+						"Target": {
+							"Type": "[PropertyName]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": "v",
+							"Arguments": null
+						},
+						"Source": {
+							"Type": "[ArrayInitializer]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[Type]",
+									"ResolvedType": {
+										"Name": "bool",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "i64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 4,
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "bool",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": true,
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "bool",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": false,
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "bool",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": false,
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "bool",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": true,
+									"Arguments": null
+								}
+							]
+						}
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "w",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[ObjectInitializer]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[Type]",
+									"ResolvedType": {
+										"Name": "a",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "ustring",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "b",
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "ustring",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "c",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "x",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[ArrayAccessor]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "v",
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "i64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 0,
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				}
+			]
+		},
+		{
+			"Name": "allTypeModifiers",
+			"Parameters": [
+				{
+					"Name": "b",
+					"Type": {
+						"Name": "Array",
+						"ToInferType": false,
+						"InnerType": {
+							"Name": "Pointer",
+							"ToInferType": false,
+							"InnerType": {
+								"Name": "Array",
+								"ToInferType": false,
+								"InnerType": {
+									"Name": "Array",
+									"ToInferType": false,
+									"InnerType": {
+										"Name": "Array",
+										"ToInferType": false,
+										"InnerType": {
+											"Name": "Pointer",
+											"ToInferType": false,
+											"InnerType": {
+												"Name": "Pointer",
+												"ToInferType": false,
+												"InnerType": {
+													"Name": "generalType",
+													"ToInferType": false,
+													"InnerType": {
+														"Name": "bool",
+														"ToInferType": false,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"Public": false,
+													"Static": false,
+													"Mutable": false
+												},
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"Public": false,
+						"Static": false,
+						"Mutable": true
+					}
+				},
+				{
+					"Name": "a",
+					"Type": {
+						"Name": "Pointer",
+						"ToInferType": false,
+						"InnerType": {
+							"Name": "Pointer",
+							"ToInferType": false,
+							"InnerType": {
+								"Name": "Pointer",
+								"ToInferType": false,
+								"InnerType": {
+									"Name": "Pointer",
+									"ToInferType": false,
+									"InnerType": {
+										"Name": "Array",
+										"ToInferType": false,
+										"InnerType": {
+											"Name": "Pointer",
+											"ToInferType": false,
+											"InnerType": {
+												"Name": "Array",
+												"ToInferType": false,
+												"InnerType": {
+													"Name": "bool",
+													"ToInferType": false,
+													"InnerType": null,
+													"Public": false,
+													"Static": false,
+													"Mutable": false
+												},
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					}
+				}
+			],
+			"ReturnType": {
+				"Name": "",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Body": []
+		}
+	]
+}

--- a/src/ast/testdata/complex.nop
+++ b/src/ast/testdata/complex.nop
@@ -1,0 +1,107 @@
+//This file should contain all possible Nop AST constructs that can be crammed into one file.
+//Obviously it won't be a reasonable file. Do not take this as a guideline on how to write Nop code.
+
+#compilerPragmaA
+#compilerPragmaB
+#compilerPragmaC
+#FailAfterASTGeneration
+
+import (
+	packageA, packageB, packageC
+)
+
+struct a {
+	pub p i32,
+	q i32, pub r i64
+}
+pub struct b {
+	a, b, c i32,
+	d, e, f f32
+}
+
+trait c {
+	fn whatAreYouTalkingAbout(d i32, e, f i64) ustring
+	fn noOpThx()
+}
+
+impl c for a {
+	fn whatAreYouTalkingAbout(d i32, e, f i64) ustring {
+		return "I am cute"
+	}
+	fn noOpThx() {
+	}
+}
+
+let d = 3
+let (e, f i64, g f64) = packageA.someMysteriousFunction()
+
+const (h, i, j) = packageB.iDareYouChangeUs() //Compilation error if h, i or j is modified
+
+fn main() {
+	let x = 3
+	let y i64 = 5
+	let (a, b i64, c f64) = packageA.someMysteriousFunction()
+	if a > 0 {
+		packageB.largerThanZero(a)
+	}
+	if b > 0 {
+		packageB.largerThanZero(b)
+	} else {
+		packageB.smallerThanZero(b)
+	}
+	match c {
+		3.0 -> packageB.largerThanZero(c)
+		2.0 -> packageA.yay(c)
+		1.0 -> {
+			packageB.iRanOutOfFunctionNames(c)
+			packageB.iAmStillRunningOutOfFunctionName(a, b, c)
+		}
+	}
+	y = 9
+	allBooleanOperators(x, y)
+	allMathOperators(x, y)
+	allMiscIdentifiers()
+}
+
+fn allBooleanOperators(a, b i64) bool {
+	//Input is 3, 9
+	//Yes. Everything in this block is allowed. Don't do it though. It's unreadable code.
+	let k = a == b //false
+	let l = a != b //true
+	let m = a < b //true
+	let n = a > b //false
+	let o = a <= b //true
+	let p = a >= b //false
+	packageB.dealWithThese(l, m, n, o, p)
+	return k
+}
+
+fn allMathOperators(a, b i64) i64 {
+	let q = a+b
+	let r = a-b
+	let s = a*b
+	let t = a/b
+	let u = a%b
+	q += a
+	r -= b
+	s *= a
+	t /= b
+	u %= b
+	packageB.dealWithThese(q, r, s, t, u)
+	return q
+}
+
+fn allMiscIdentifiers() {
+	//This block of code would not build because some part of it does not belong in global scope.
+	//It'll still parse to AST though and that's all that matters.
+	let v = *self->x
+	v = [0]bool
+	v = []bool{true, false, false, true}
+	let w = a{"b", "c"}
+	let x = v[0]
+}
+
+fn allTypeModifiers(a ****[]*[]bool, b mut []*[][][]**generalType<bool>) {
+	//Everything is in the function header :)
+	//If you do any of the types in it in real life, I'll personally hunt you down.
+}

--- a/src/ast/testdata/discord_discussion.ast.golden
+++ b/src/ast/testdata/discord_discussion.ast.golden
@@ -1,0 +1,1227 @@
+{
+	"Source": "testdata/discord_discussion.nop",
+	"CompilerPragma": [
+		"#no_std",
+		"#no_auto_free"
+	],
+	"Import": [
+		"strconv"
+	],
+	"Structs": [
+		{
+			"Public": false,
+			"Name": "Point",
+			"FieldNames": [
+				"x",
+				"y"
+			],
+			"FieldTypes": [
+				{
+					"Name": "i32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				},
+				{
+					"Name": "i32",
+					"ToInferType": false,
+					"InnerType": null,
+					"Public": false,
+					"Static": false,
+					"Mutable": false
+				}
+			]
+		}
+	],
+	"Traits": [
+		{
+			"Name": "Stringable",
+			"Functions": [
+				{
+					"Name": "string",
+					"Parameters": [],
+					"ReturnType": {
+						"Name": "string",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					},
+					"Body": null
+				}
+			]
+		}
+	],
+	"Impls": [
+		{
+			"TraitName": "Point",
+			"TypeName": {
+				"Name": "",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Implementations": [
+				{
+					"Name": "new",
+					"Parameters": [
+						{
+							"Name": "x",
+							"Type": {
+								"Name": "i32",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						},
+						{
+							"Name": "y",
+							"Type": {
+								"Name": "i32",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						}
+					],
+					"ReturnType": {
+						"Name": "Point",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					},
+					"Body": [
+						{
+							"Type": "[ReturnStatement]",
+							"Actual": {
+								"Type": "[ObjectInitializer]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": false,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": null,
+								"Arguments": [
+									{
+										"Type": "[Type]",
+										"ResolvedType": {
+											"Name": "Point",
+											"ToInferType": false,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": null,
+										"Arguments": null
+									},
+									{
+										"Type": "[PropertyName]",
+										"ResolvedType": {
+											"Name": "",
+											"ToInferType": true,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": "x",
+										"Arguments": null
+									},
+									{
+										"Type": "[PropertyName]",
+										"ResolvedType": {
+											"Name": "",
+											"ToInferType": true,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": "y",
+										"Arguments": null
+									}
+								]
+							}
+						}
+					]
+				},
+				{
+					"Name": "translate",
+					"Parameters": [
+						{
+							"Name": "x",
+							"Type": {
+								"Name": "i32",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						},
+						{
+							"Name": "y",
+							"Type": {
+								"Name": "i32",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							}
+						},
+						{
+							"Name": "self",
+							"Type": {
+								"Name": "self",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": true
+							}
+						}
+					],
+					"ReturnType": {
+						"Name": "",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					},
+					"Body": [
+						{
+							"Type": "[Assignment]",
+							"Actual": {
+								"Target": {
+									"Type": "[PointerAccess]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[Self]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": false,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": null
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "x",
+											"Arguments": null
+										}
+									]
+								},
+								"Source": {
+									"Type": "[Addition]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[PointerAccess]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": [
+												{
+													"Type": "[Self]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": false,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": null,
+													"Arguments": null
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "x",
+													"Arguments": null
+												}
+											]
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "x",
+											"Arguments": null
+										}
+									]
+								}
+							}
+						},
+						{
+							"Type": "[Assignment]",
+							"Actual": {
+								"Target": {
+									"Type": "[PointerAccess]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[Self]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": false,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": null
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "y",
+											"Arguments": null
+										}
+									]
+								},
+								"Source": {
+									"Type": "[Addition]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[PointerAccess]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": null,
+											"Arguments": [
+												{
+													"Type": "[Self]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": false,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": null,
+													"Arguments": null
+												},
+												{
+													"Type": "[PropertyName]",
+													"ResolvedType": {
+														"Name": "",
+														"ToInferType": true,
+														"InnerType": null,
+														"Public": false,
+														"Static": false,
+														"Mutable": false
+													},
+													"LiteralValue": "y",
+													"Arguments": null
+												}
+											]
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "y",
+											"Arguments": null
+										}
+									]
+								}
+							}
+						}
+					]
+				}
+			]
+		},
+		{
+			"TraitName": "Stringable",
+			"TypeName": {
+				"Name": "Point",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Implementations": [
+				{
+					"Name": "string",
+					"Parameters": [
+						{
+							"Name": "self",
+							"Type": {
+								"Name": "self",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": true
+							}
+						}
+					],
+					"ReturnType": {
+						"Name": "string",
+						"ToInferType": false,
+						"InnerType": null,
+						"Public": false,
+						"Static": false,
+						"Mutable": false
+					},
+					"Body": [
+						{
+							"Type": "[ReturnStatement]",
+							"Actual": {
+								"Type": "[Addition]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": null,
+								"Arguments": [
+									{
+										"Type": "[Addition]",
+										"ResolvedType": {
+											"Name": "",
+											"ToInferType": true,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": null,
+										"Arguments": [
+											{
+												"Type": "[Addition]",
+												"ResolvedType": {
+													"Name": "",
+													"ToInferType": true,
+													"InnerType": null,
+													"Public": false,
+													"Static": false,
+													"Mutable": false
+												},
+												"LiteralValue": null,
+												"Arguments": [
+													{
+														"Type": "[Addition]",
+														"ResolvedType": {
+															"Name": "",
+															"ToInferType": true,
+															"InnerType": null,
+															"Public": false,
+															"Static": false,
+															"Mutable": false
+														},
+														"LiteralValue": null,
+														"Arguments": [
+															{
+																"Type": "[Literal]",
+																"ResolvedType": {
+																	"Name": "ustring",
+																	"ToInferType": false,
+																	"InnerType": null,
+																	"Public": false,
+																	"Static": false,
+																	"Mutable": false
+																},
+																"LiteralValue": "(",
+																"Arguments": null
+															},
+															{
+																"Type": "[FunctionCall]",
+																"ResolvedType": {
+																	"Name": "",
+																	"ToInferType": false,
+																	"InnerType": null,
+																	"Public": false,
+																	"Static": false,
+																	"Mutable": false
+																},
+																"LiteralValue": null,
+																"Arguments": [
+																	{
+																		"Type": "[Property]",
+																		"ResolvedType": {
+																			"Name": "",
+																			"ToInferType": true,
+																			"InnerType": null,
+																			"Public": false,
+																			"Static": false,
+																			"Mutable": false
+																		},
+																		"LiteralValue": null,
+																		"Arguments": [
+																			{
+																				"Type": "[PropertyName]",
+																				"ResolvedType": {
+																					"Name": "",
+																					"ToInferType": true,
+																					"InnerType": null,
+																					"Public": false,
+																					"Static": false,
+																					"Mutable": false
+																				},
+																				"LiteralValue": "strconv",
+																				"Arguments": null
+																			},
+																			{
+																				"Type": "[PropertyName]",
+																				"ResolvedType": {
+																					"Name": "",
+																					"ToInferType": true,
+																					"InnerType": null,
+																					"Public": false,
+																					"Static": false,
+																					"Mutable": false
+																				},
+																				"LiteralValue": "Atoi",
+																				"Arguments": null
+																			}
+																		]
+																	},
+																	{
+																		"Type": "[PointerAccess]",
+																		"ResolvedType": {
+																			"Name": "",
+																			"ToInferType": true,
+																			"InnerType": null,
+																			"Public": false,
+																			"Static": false,
+																			"Mutable": false
+																		},
+																		"LiteralValue": null,
+																		"Arguments": [
+																			{
+																				"Type": "[Self]",
+																				"ResolvedType": {
+																					"Name": "",
+																					"ToInferType": false,
+																					"InnerType": null,
+																					"Public": false,
+																					"Static": false,
+																					"Mutable": false
+																				},
+																				"LiteralValue": null,
+																				"Arguments": null
+																			},
+																			{
+																				"Type": "[PropertyName]",
+																				"ResolvedType": {
+																					"Name": "",
+																					"ToInferType": true,
+																					"InnerType": null,
+																					"Public": false,
+																					"Static": false,
+																					"Mutable": false
+																				},
+																				"LiteralValue": "x",
+																				"Arguments": null
+																			}
+																		]
+																	}
+																]
+															}
+														]
+													},
+													{
+														"Type": "[Literal]",
+														"ResolvedType": {
+															"Name": "ustring",
+															"ToInferType": false,
+															"InnerType": null,
+															"Public": false,
+															"Static": false,
+															"Mutable": false
+														},
+														"LiteralValue": ", ",
+														"Arguments": null
+													}
+												]
+											},
+											{
+												"Type": "[FunctionCall]",
+												"ResolvedType": {
+													"Name": "",
+													"ToInferType": false,
+													"InnerType": null,
+													"Public": false,
+													"Static": false,
+													"Mutable": false
+												},
+												"LiteralValue": null,
+												"Arguments": [
+													{
+														"Type": "[Property]",
+														"ResolvedType": {
+															"Name": "",
+															"ToInferType": true,
+															"InnerType": null,
+															"Public": false,
+															"Static": false,
+															"Mutable": false
+														},
+														"LiteralValue": null,
+														"Arguments": [
+															{
+																"Type": "[PropertyName]",
+																"ResolvedType": {
+																	"Name": "",
+																	"ToInferType": true,
+																	"InnerType": null,
+																	"Public": false,
+																	"Static": false,
+																	"Mutable": false
+																},
+																"LiteralValue": "strconv",
+																"Arguments": null
+															},
+															{
+																"Type": "[PropertyName]",
+																"ResolvedType": {
+																	"Name": "",
+																	"ToInferType": true,
+																	"InnerType": null,
+																	"Public": false,
+																	"Static": false,
+																	"Mutable": false
+																},
+																"LiteralValue": "Atoi",
+																"Arguments": null
+															}
+														]
+													},
+													{
+														"Type": "[PointerAccess]",
+														"ResolvedType": {
+															"Name": "",
+															"ToInferType": true,
+															"InnerType": null,
+															"Public": false,
+															"Static": false,
+															"Mutable": false
+														},
+														"LiteralValue": null,
+														"Arguments": [
+															{
+																"Type": "[Self]",
+																"ResolvedType": {
+																	"Name": "",
+																	"ToInferType": false,
+																	"InnerType": null,
+																	"Public": false,
+																	"Static": false,
+																	"Mutable": false
+																},
+																"LiteralValue": null,
+																"Arguments": null
+															},
+															{
+																"Type": "[PropertyName]",
+																"ResolvedType": {
+																	"Name": "",
+																	"ToInferType": true,
+																	"InnerType": null,
+																	"Public": false,
+																	"Static": false,
+																	"Mutable": false
+																},
+																"LiteralValue": "y",
+																"Arguments": null
+															}
+														]
+													}
+												]
+											}
+										]
+									},
+									{
+										"Type": "[Literal]",
+										"ResolvedType": {
+											"Name": "ustring",
+											"ToInferType": false,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": ")",
+										"Arguments": null
+									}
+								]
+							}
+						}
+					]
+				}
+			]
+		}
+	],
+	"Globals": null,
+	"Constants": null,
+	"Functions": [
+		{
+			"Name": "main",
+			"Parameters": [],
+			"ReturnType": {
+				"Name": "",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Body": [
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "pointA",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[FunctionCall]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": false,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[Property]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "Point",
+											"Arguments": null
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "new",
+											"Arguments": null
+										}
+									]
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "i64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 123,
+									"Arguments": null
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "i64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 456,
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[VariableDecl]",
+					"Actual": {
+						"Targets": [
+							{
+								"Name": "pointB",
+								"Type": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": true
+								}
+							}
+						],
+						"DefaultValue": {
+							"Type": "[Property]",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "pointA",
+									"Arguments": null
+								},
+								{
+									"Type": "[PropertyName]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": "clone",
+									"Arguments": null
+								}
+							]
+						},
+						"IsConstant": false
+					}
+				},
+				{
+					"Type": "[EvaluatedStatement]",
+					"Actual": {
+						"Type": "[FunctionCall]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": false,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[Property]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": null,
+								"Arguments": [
+									{
+										"Type": "[PropertyName]",
+										"ResolvedType": {
+											"Name": "",
+											"ToInferType": true,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": "pointB",
+										"Arguments": null
+									},
+									{
+										"Type": "[PropertyName]",
+										"ResolvedType": {
+											"Name": "",
+											"ToInferType": true,
+											"InnerType": null,
+											"Public": false,
+											"Static": false,
+											"Mutable": false
+										},
+										"LiteralValue": "translate",
+										"Arguments": null
+									}
+								]
+							},
+							{
+								"Type": "[Literal]",
+								"ResolvedType": {
+									"Name": "i64",
+									"ToInferType": false,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": 5,
+								"Arguments": null
+							},
+							{
+								"Type": "[Literal]",
+								"ResolvedType": {
+									"Name": "i64",
+									"ToInferType": false,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": 3,
+								"Arguments": null
+							}
+						]
+					}
+				},
+				{
+					"Type": "[IfStatement]",
+					"Actual": {
+						"Condition": {
+							"Type": "\u003c",
+							"ResolvedType": {
+								"Name": "",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": false
+							},
+							"LiteralValue": null,
+							"Arguments": [
+								{
+									"Type": "[Property]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": true,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "pointB",
+											"Arguments": null
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "x",
+											"Arguments": null
+										}
+									]
+								},
+								{
+									"Type": "[Literal]",
+									"ResolvedType": {
+										"Name": "i64",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": 100,
+									"Arguments": null
+								}
+							]
+						},
+						"IfBlock": [
+							{
+								"Type": "[EvaluatedStatement]",
+								"Actual": {
+									"Type": "[FunctionCall]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "println",
+											"Arguments": null
+										},
+										{
+											"Type": "[Literal]",
+											"ResolvedType": {
+												"Name": "ustring",
+												"ToInferType": false,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "Should never execute",
+											"Arguments": null
+										}
+									]
+								}
+							}
+						],
+						"ElseBlock": [
+							{
+								"Type": "[EvaluatedStatement]",
+								"Actual": {
+									"Type": "[FunctionCall]",
+									"ResolvedType": {
+										"Name": "",
+										"ToInferType": false,
+										"InnerType": null,
+										"Public": false,
+										"Static": false,
+										"Mutable": false
+									},
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "println",
+											"Arguments": null
+										},
+										{
+											"Type": "[Literal]",
+											"ResolvedType": {
+												"Name": "ustring",
+												"ToInferType": false,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "Should always execute",
+											"Arguments": null
+										}
+									]
+								}
+							}
+						]
+					}
+				},
+				{
+					"Type": "[EvaluatedStatement]",
+					"Actual": {
+						"Type": "[FunctionCall]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": false,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "println",
+								"Arguments": null
+							},
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "pointB",
+								"Arguments": null
+							}
+						]
+					}
+				}
+			]
+		}
+	]
+}

--- a/src/ast/testdata/discord_discussion.ast.golden
+++ b/src/ast/testdata/discord_discussion.ast.golden
@@ -164,6 +164,17 @@
 					"Name": "translate",
 					"Parameters": [
 						{
+							"Name": "self",
+							"Type": {
+								"Name": "self",
+								"ToInferType": true,
+								"InnerType": null,
+								"Public": false,
+								"Static": false,
+								"Mutable": true
+							}
+						},
+						{
 							"Name": "x",
 							"Type": {
 								"Name": "i32",
@@ -183,17 +194,6 @@
 								"Public": false,
 								"Static": false,
 								"Mutable": false
-							}
-						},
-						{
-							"Name": "self",
-							"Type": {
-								"Name": "self",
-								"ToInferType": true,
-								"InnerType": null,
-								"Public": false,
-								"Static": false,
-								"Mutable": true
 							}
 						}
 					],

--- a/src/ast/testdata/discord_discussion.ast.golden
+++ b/src/ast/testdata/discord_discussion.ast.golden
@@ -20,7 +20,7 @@
 					"Name": "i32",
 					"ToInferType": false,
 					"InnerType": null,
-					"Public": false,
+					"Public": true,
 					"Static": false,
 					"Mutable": false
 				},
@@ -28,7 +28,7 @@
 					"Name": "i32",
 					"ToInferType": false,
 					"InnerType": null,
-					"Public": false,
+					"Public": true,
 					"Static": false,
 					"Mutable": false
 				}

--- a/src/ast/testdata/discord_discussion.ast.golden
+++ b/src/ast/testdata/discord_discussion.ast.golden
@@ -536,7 +536,7 @@
 																"Type": "[FunctionCall]",
 																"ResolvedType": {
 																	"Name": "",
-																	"ToInferType": false,
+																	"ToInferType": true,
 																	"InnerType": null,
 																	"Public": false,
 																	"Static": false,
@@ -647,7 +647,7 @@
 												"Type": "[FunctionCall]",
 												"ResolvedType": {
 													"Name": "",
-													"ToInferType": false,
+													"ToInferType": true,
 													"InnerType": null,
 													"Public": false,
 													"Static": false,
@@ -795,7 +795,7 @@
 							"Type": "[FunctionCall]",
 							"ResolvedType": {
 								"Name": "",
-								"ToInferType": false,
+								"ToInferType": true,
 								"InnerType": null,
 								"Public": false,
 								"Static": false,
@@ -891,7 +891,7 @@
 							}
 						],
 						"DefaultValue": {
-							"Type": "[Property]",
+							"Type": "[FunctionCall]",
 							"ResolvedType": {
 								"Name": "",
 								"ToInferType": true,
@@ -903,7 +903,7 @@
 							"LiteralValue": null,
 							"Arguments": [
 								{
-									"Type": "[PropertyName]",
+									"Type": "[Property]",
 									"ResolvedType": {
 										"Name": "",
 										"ToInferType": true,
@@ -912,21 +912,35 @@
 										"Static": false,
 										"Mutable": false
 									},
-									"LiteralValue": "pointA",
-									"Arguments": null
-								},
-								{
-									"Type": "[PropertyName]",
-									"ResolvedType": {
-										"Name": "",
-										"ToInferType": true,
-										"InnerType": null,
-										"Public": false,
-										"Static": false,
-										"Mutable": false
-									},
-									"LiteralValue": "clone",
-									"Arguments": null
+									"LiteralValue": null,
+									"Arguments": [
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "pointA",
+											"Arguments": null
+										},
+										{
+											"Type": "[PropertyName]",
+											"ResolvedType": {
+												"Name": "",
+												"ToInferType": true,
+												"InnerType": null,
+												"Public": false,
+												"Static": false,
+												"Mutable": false
+											},
+											"LiteralValue": "clone",
+											"Arguments": null
+										}
+									]
 								}
 							]
 						},
@@ -939,7 +953,7 @@
 						"Type": "[FunctionCall]",
 						"ResolvedType": {
 							"Name": "",
-							"ToInferType": false,
+							"ToInferType": true,
 							"InnerType": null,
 							"Public": false,
 							"Static": false,
@@ -1093,7 +1107,7 @@
 									"Type": "[FunctionCall]",
 									"ResolvedType": {
 										"Name": "",
-										"ToInferType": false,
+										"ToInferType": true,
 										"InnerType": null,
 										"Public": false,
 										"Static": false,
@@ -1138,7 +1152,7 @@
 									"Type": "[FunctionCall]",
 									"ResolvedType": {
 										"Name": "",
-										"ToInferType": false,
+										"ToInferType": true,
 										"InnerType": null,
 										"Public": false,
 										"Static": false,
@@ -1184,7 +1198,7 @@
 						"Type": "[FunctionCall]",
 						"ResolvedType": {
 							"Name": "",
-							"ToInferType": false,
+							"ToInferType": true,
 							"InnerType": null,
 							"Public": false,
 							"Static": false,

--- a/src/ast/testdata/discord_discussion.ast.golden
+++ b/src/ast/testdata/discord_discussion.ast.golden
@@ -107,7 +107,7 @@
 							"Actual": {
 								"Type": "[ObjectInitializer]",
 								"ResolvedType": {
-									"Name": "",
+									"Name": "Point",
 									"ToInferType": false,
 									"InnerType": null,
 									"Public": false,
@@ -225,7 +225,7 @@
 											"Type": "[Self]",
 											"ResolvedType": {
 												"Name": "",
-												"ToInferType": false,
+												"ToInferType": true,
 												"InnerType": null,
 												"Public": false,
 												"Static": false,
@@ -277,7 +277,7 @@
 													"Type": "[Self]",
 													"ResolvedType": {
 														"Name": "",
-														"ToInferType": false,
+														"ToInferType": true,
 														"InnerType": null,
 														"Public": false,
 														"Static": false,
@@ -337,7 +337,7 @@
 											"Type": "[Self]",
 											"ResolvedType": {
 												"Name": "",
-												"ToInferType": false,
+												"ToInferType": true,
 												"InnerType": null,
 												"Public": false,
 												"Static": false,
@@ -389,7 +389,7 @@
 													"Type": "[Self]",
 													"ResolvedType": {
 														"Name": "",
-														"ToInferType": false,
+														"ToInferType": true,
 														"InnerType": null,
 														"Public": false,
 														"Static": false,
@@ -600,7 +600,7 @@
 																				"Type": "[Self]",
 																				"ResolvedType": {
 																					"Name": "",
-																					"ToInferType": false,
+																					"ToInferType": true,
 																					"InnerType": null,
 																					"Public": false,
 																					"Static": false,
@@ -711,7 +711,7 @@
 																"Type": "[Self]",
 																"ResolvedType": {
 																	"Name": "",
-																	"ToInferType": false,
+																	"ToInferType": true,
 																	"InnerType": null,
 																	"Public": false,
 																	"Static": false,

--- a/src/ast/testdata/discord_discussion.nop
+++ b/src/ast/testdata/discord_discussion.nop
@@ -1,0 +1,45 @@
+// unclear
+#no_std
+#no_auto_free
+
+// unclear
+import strconv
+
+struct Point {
+    pub x, y i32 // Types don't matter in antlr files for now
+}
+
+fn main() {
+    // change to dot if no double colon
+    let pointA = Point.new(123, 456)
+
+    let mut pointB = pointA.clone()
+    pointB.translate(5, 3)
+    if pointB.x < 100 {
+        println("Should never execute")
+    } else {
+        println("Should always execute")
+    }
+    println(pointB) //(128, 459)
+}
+
+impl Point {
+    fn new(x, y i32) Point {
+        return Point{x, y}
+    }
+    fn translate(*mut self, x, y i32) {
+        self->x += x
+        self->y += y
+    }
+}
+
+impl Stringable for Point {
+    fn string(*mut self) string {
+         return "(" + strconv.Atoi(self->x) + ", " + strconv.Atoi(self->y) + ")"
+    }
+}
+
+//In internal compiler files
+trait Stringable {
+    fn string() string
+}

--- a/src/ast/testdata/helloworld.ast.golden
+++ b/src/ast/testdata/helloworld.ast.golden
@@ -1,0 +1,69 @@
+{
+	"Source": "testdata/helloworld.nop",
+	"CompilerPragma": [],
+	"Import": null,
+	"Structs": null,
+	"Traits": null,
+	"Impls": null,
+	"Globals": null,
+	"Constants": null,
+	"Functions": [
+		{
+			"Name": "main",
+			"Parameters": [],
+			"ReturnType": {
+				"Name": "",
+				"ToInferType": false,
+				"InnerType": null,
+				"Public": false,
+				"Static": false,
+				"Mutable": false
+			},
+			"Body": [
+				{
+					"Type": "[EvaluatedStatement]",
+					"Actual": {
+						"Type": "[FunctionCall]",
+						"ResolvedType": {
+							"Name": "",
+							"ToInferType": false,
+							"InnerType": null,
+							"Public": false,
+							"Static": false,
+							"Mutable": false
+						},
+						"LiteralValue": null,
+						"Arguments": [
+							{
+								"Type": "[PropertyName]",
+								"ResolvedType": {
+									"Name": "",
+									"ToInferType": true,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "println",
+								"Arguments": null
+							},
+							{
+								"Type": "[Literal]",
+								"ResolvedType": {
+									"Name": "ustring",
+									"ToInferType": false,
+									"InnerType": null,
+									"Public": false,
+									"Static": false,
+									"Mutable": false
+								},
+								"LiteralValue": "Hello World!",
+								"Arguments": null
+							}
+						]
+					}
+				}
+			]
+		}
+	]
+}

--- a/src/ast/testdata/helloworld.ast.golden
+++ b/src/ast/testdata/helloworld.ast.golden
@@ -26,7 +26,7 @@
 						"Type": "[FunctionCall]",
 						"ResolvedType": {
 							"Name": "",
-							"ToInferType": false,
+							"ToInferType": true,
 							"InnerType": null,
 							"Public": false,
 							"Static": false,

--- a/src/ast/testdata/helloworld.nop
+++ b/src/ast/testdata/helloworld.nop
@@ -1,0 +1,7 @@
+//This is what Hello World would look like in Noplang.
+//I would really question life if something breaks the compilation of this file.
+//Maybe you should if you are the person who broke compilation of this file.
+
+fn main() {
+	println("Hello World!")
+}

--- a/src/ast/testdata/lexer_fail.nop
+++ b/src/ast/testdata/lexer_fail.nop
@@ -1,0 +1,2 @@
+//This file just has one invalid token and this comment which is dropped by Antlr.
+iAmNotAToken_UnderscoreIsToMakeSureIt'sNotMistakenAsAnIdentifier

--- a/src/ast/testdata/parser_fail.nop
+++ b/src/ast/testdata/parser_fail.nop
@@ -1,0 +1,2 @@
+//These tokens make sense to the lexer, but not to the parser. Not to me too.
+import import import

--- a/src/ast/testdata/pretty_print_clean.json.golden
+++ b/src/ast/testdata/pretty_print_clean.json.golden
@@ -1,0 +1,11 @@
+{
+	"Source": "",
+	"CompilerPragma": null,
+	"Import": null,
+	"Structs": null,
+	"Traits": null,
+	"Impls": null,
+	"Globals": null,
+	"Constants": null,
+	"Functions": null
+}

--- a/src/main.go
+++ b/src/main.go
@@ -25,7 +25,7 @@ func main() {
 		flags.OutputLocation = strings.TrimSuffix(files[0], ".nop")
 	}
 	flags.DebugPrint("Output file location: " + flags.OutputLocation)
-	astTree := generateAST(parsedTree)
+	astTree := ast.GenerateAST(parsedTree)
 	if flags.EmitAST {
 		for _, v := range astTree {
 			ast.PrettyPrintASTToFile(v)

--- a/src/parser.go
+++ b/src/parser.go
@@ -8,53 +8,11 @@ import (
 
 	"github.com/noplang/nopc-go/ast"
 	"github.com/noplang/nopc-go/flags"
-	"github.com/noplang/nopc-go/parser"
-
-	"github.com/antlr/antlr4/runtime/Go/antlr"
 )
 
-type parseTreeWithLocation struct {
-	Tree     antlr.ParseTree
-	Location string
-}
-
-func parseFile(location string) *parseTreeWithLocation {
-	input, err := antlr.NewFileStream(location)
-	if err != nil {
-		fmt.Println(location + ": Error parsing file through antlr: " + err.Error())
-		return nil
-	}
-
-	lexerError := errorListener{}
-	parserError := errorListener{}
-
-	lexer := parser.NewnopLexer(input)
-	lexer.AddErrorListener(&lexerError)
-
-	stream := antlr.NewCommonTokenStream(lexer, 0)
-
-	parser := parser.NewnopParser(stream)
-	parser.BuildParseTrees = true
-	parser.AddErrorListener(&parserError)
-	tree := parser.Nop_file()
-
-	if lexerError.EncounteredError {
-		fmt.Println(location + ": Failed to tokenize file")
-		return nil
-	}
-	if parserError.EncounteredError {
-		fmt.Println(location + ": Failed to parse file")
-		return nil
-	}
-	return &parseTreeWithLocation{
-		Tree:     tree,
-		Location: location,
-	}
-}
-
-func parseFiles(location []string) ([]parseTreeWithLocation, bool) {
+func parseFiles(location []string) ([]ast.ParseTreeWithLocation, bool) {
 	var encounteredError bool
-	result := make([]parseTreeWithLocation, 0, len(location))
+	result := make([]ast.ParseTreeWithLocation, 0, len(location))
 	for i := 0; i < len(location); i++ {
 		err := filepath.Walk(location[i], func(path string, info os.FileInfo, err error) error {
 			if info.IsDir() {
@@ -64,7 +22,7 @@ func parseFiles(location []string) ([]parseTreeWithLocation, bool) {
 				return nil //Nop file only
 			}
 			flags.DebugPrint(path + ": processing")
-			nextTree := parseFile(path)
+			nextTree := ast.ParseFile(path)
 			if nextTree == nil {
 				flags.DebugPrint(path + ": skipping file due to error")
 				encounteredError = true
@@ -81,17 +39,4 @@ func parseFiles(location []string) ([]parseTreeWithLocation, bool) {
 		}
 	}
 	return result, encounteredError
-}
-
-func generateAST(parseTrees []parseTreeWithLocation) []ast.NopFile {
-	result := make([]ast.NopFile, 0, len(parseTrees))
-	for i, v := range parseTrees {
-		flags.DebugPrint(v.Location + ": walking tree")
-		astWalker := ast.NewNopListener()
-		nopTree := astWalker.Walk(parseTrees[i].Tree)
-		nopTree.Source = parseTrees[i].Location
-		result = append(result, nopTree)
-		flags.DebugPrint(v.Location + ": walked tree")
-	}
-	return result
 }


### PR DESCRIPTION
I apologize for the very generic title.
This commit adds GoDoc and tests for the AST package.
I've noticed a few incorrect outputs while working on the tests so they are resolved in this PR as well.

Some explanation on why I did what I did:
1. Moving some AST/parser-specific code from main to AST.
I did it so AST generation code can be tested from the AST package instead of flooding the main package with a lot of test files.
2. Golden files
I'm sure you've noticed very large files with the extension ".ast.golden". They're really just the AST generated from the test code. These are kept in the repo as they are the expected result of the AST functionality.
3. Write terrible Nop code.
Pointers to pointers to arrays to pointers. I despise them too. These very awkward types are there because we want to make sure it still works correctly even when users of the compiler actually try to use it (for some reason).

Thanks for taking your time to review this pull request. ^^